### PR TITLE
allow multiple v6 destinations, randomly chosen

### DIFF
--- a/nc64.py
+++ b/nc64.py
@@ -17,7 +17,6 @@
 # 2. SSL signing and handshake for SSH, HTTPS traffic spoofing
 # 3. Custom SSL certificate provision
 # 4. Logging instead of printing verbose messages on the screen
-# 5. Multiple IPv6 destination addresses as list for random selection
 __version__ = "0.72.1/Devon"
 
 import socket
@@ -57,7 +56,7 @@ def send64(data, mode):
     if version == 4:
         host = args.host4
     if version == 6:
-        host = args.host6
+        host = random.choice(args.host6)
 
     if not args.udp and not args.tcp:
         if args.verbose >= 2:
@@ -350,8 +349,9 @@ parser.add_argument(
 
 parser.add_argument(
     '-h6', '--host6',
+    nargs='+',
     type=str,
-    default="::1",
+    default=["::1"],
     help="Host IPv6 address. Default: ::1")
 
 parser.add_argument(


### PR DESCRIPTION
I'm using this tool to demonstrate some of the possible IPv6 pitfalls, and thought it to be a bit more interesting if we spread the exfil over a larger-than-one set of destination IPv6 addresses.

This pretty much implements "todo item #5" in nc64.py :)